### PR TITLE
Fix image paths in documentation

### DIFF
--- a/docs/Guide-OpenMower-Mowgli/injection-firmware.md
+++ b/docs/Guide-OpenMower-Mowgli/injection-firmware.md
@@ -6,7 +6,7 @@ parent: "🏠 Guide OpenMower"
 layout: default
 ---
 <div style={{textAlign:"center"}}>
-  <img src="img/injection_firmware_cover.png" alt="Illustration firmware" style={{maxWidth:"200px", margin:"1rem auto", borderRadius:"10px", boxShadow:"0 2px 6px rgba(0,0,0,0.2)"}} />
+  <img src="/img/injection_firmware_cover.png" alt="Illustration firmware" style={{maxWidth:"200px", margin:"1rem auto", borderRadius:"10px", boxShadow:"0 2px 6px rgba(0,0,0,0.2)"}} />
 </div>
 
 
@@ -25,7 +25,7 @@ Avant toute modification, sauvegardez votre firmware actuel avec un **STLINK** (
 **Branchement STLINK** :
 
 <div style={{textAlign:"center"}}>
-  <img src="img/branchement_stlink.jpg" alt="Schéma de connexion STLINK" style={{maxWidth:"300px", margin:"auto"}} />
+  <img src="/img/branchement_stlink.jpg" alt="Schéma de connexion STLINK" style={{maxWidth:"300px", margin:"auto"}} />
 </div>
 
 <div class="alert-blue">

--- a/docs/Guide-OpenMower-Mowgli/serigraphie-Mowgli.md
+++ b/docs/Guide-OpenMower-Mowgli/serigraphie-Mowgli.md
@@ -15,7 +15,7 @@ Découvrez ici la disposition des boutons et voyants de votre robot Yardforce mo
 ### 📷 Photo du panneau réel (500/500B)
 
 <div style={{ textAlign: "center" }}>
-  <img src="img/illustration-serigraphie1.jpg" alt="Illustration panneau Yardforce" width="400px" />
+  <img src="/img/illustration-serigraphie1.jpg" alt="Illustration panneau Yardforce" width="400px" />
 </div>
 
 ---
@@ -23,14 +23,14 @@ Découvrez ici la disposition des boutons et voyants de votre robot Yardforce mo
 ### 📷 Photo du panneau réel (SA900)
 
 <div style={{ textAlign: "center" }}>
-  <img src="img/illustration-serigraphie1.jpg" alt="Illustration panneau Yardforce" width="400px" />
+  <img src="/img/illustration-serigraphie1.jpg" alt="Illustration panneau Yardforce" width="400px" />
 </div>
 
 ---
 ### 🖨️ Modèle 3D imprimable (version DIY)
 
 <div style={{ textAlign: "center" }}>
-  <img src="img/illustration-serigraphie.png" alt="Aperçu modèle 3D panneau Yardforce" width="400px" />
+  <img src="/img/illustration-serigraphie.png" alt="Aperçu modèle 3D panneau Yardforce" width="400px" />
 </div>
 
 <div className="alert alert--warning" style={{ textAlign: "center" }}>
@@ -41,7 +41,7 @@ Découvrez ici la disposition des boutons et voyants de votre robot Yardforce mo
 ### 🖨️ Version imprimable Stickers (version DIY)
 
 <div style={{ textAlign: "center" }}>
-  <img src="img/illustration-serigraphie.png" alt="Illustration panneau Yardforce" width="400px" />
+  <img src="/img/illustration-serigraphie.png" alt="Illustration panneau Yardforce" width="400px" />
 </div>
 
 <div className="alert alert--warning" style={{ textAlign: "center" }}>


### PR DESCRIPTION
Fixed broken images in documentation pages due to paths being relative instead of root-relative for `static/img`.

---
*PR created automatically by Jules for task [17206237157126630991](https://jules.google.com/task/17206237157126630991) started by @juditech3D*